### PR TITLE
Ppo/polar voxel

### DIFF
--- a/flightlib/include/flightlib/envs/vision_env/vision_env.hpp
+++ b/flightlib/include/flightlib/envs/vision_env/vision_env.hpp
@@ -35,7 +35,7 @@ enum Vision : int {
 
   kNCuts = 8,
 
-  kNFreePaths = 9,
+  kNFreePaths = 16,
   kNFreePathsState = 4,
 
   // observations

--- a/flightlib/include/flightlib/envs/vision_env/vision_env.hpp
+++ b/flightlib/include/flightlib/envs/vision_env/vision_env.hpp
@@ -30,12 +30,12 @@ enum Vision : int {
   //
   kNQuadState = 25,
 
-  kNObstacles = 10,
+  kNObstacles = 15,
   kNObstaclesState = 7,
 
   kNCuts = 8,
 
-  kNFreePaths = 16,
+  kNFreePaths = 9,
   kNFreePathsState = 4,
 
   // observations

--- a/flightlib/include/flightlib/envs/vision_env/vision_env.hpp
+++ b/flightlib/include/flightlib/envs/vision_env/vision_env.hpp
@@ -34,11 +34,13 @@ enum Vision : int {
   kNObstaclesState = 7,
 
   kNCuts = 8,
+
+  kNFreePaths = 9,
   kNFreePathsState = 4,
 
   // observations
   kObs = 0,
-  kNObs = 15 + kNObstacles * kNObstaclesState + kNCuts * kNCuts * kNFreePathsState,
+  kNObs = 15 + kNObstacles * kNObstaclesState + kNFreePaths * kNFreePathsState,
 
   // control actions
   kAct = 0,

--- a/flightlib/include/flightlib/envs/vision_env/vision_env.hpp
+++ b/flightlib/include/flightlib/envs/vision_env/vision_env.hpp
@@ -33,9 +33,12 @@ enum Vision : int {
   kNObstacles = 10,
   kNObstaclesState = 7,
 
+  kNCuts = 8,
+  kNFreePathsState = 4,
+
   // observations
   kObs = 0,
-  kNObs = 15 + kNObstacles * kNObstaclesState,
+  kNObs = 15 + kNObstacles * kNObstaclesState + kNCuts * kNCuts * kNFreePathsState,
 
   // control actions
   kAct = 0,
@@ -65,7 +68,21 @@ class VisionEnv final : public EnvBase {
   bool getImage(Ref<ImgVector<>> img, const bool rgb = true) override;
   bool getDepthImage(Ref<DepthImgVector<>> img) override;
 
-  bool getObstacleState(Ref<Vector<>> obstacle_obs);
+  bool getObstacleState(Ref<Vector<>> obstacle_obs, Ref<Vector<>> free_paths_obs);
+  bool getPolarVoxel(
+    std::vector<Vector<3>, Eigen::aligned_allocator<Vector<3>>>& rel_pos_list_B,
+    std::vector<Scalar> rel_pos_norm_list,
+    std::vector<Scalar> obs_radius_list,
+    std::vector<size_t> indices_sorted,
+    Ref<Vector<>> polar_voxel);
+  Scalar getDistanceToClosestObstacle(
+    std::vector<Vector<3>, Eigen::aligned_allocator<Vector<3>>>& rel_pos_list_B,
+    std::vector<Scalar> rel_pos_norm_list,
+    std::vector<Scalar> obs_radius_list,
+    std::vector<size_t> indices_sorted,
+    Scalar f_cell, Scalar t_cell);
+  Vector<3> getCartesianFromAng(Scalar phi, Scalar theta);
+
   // get quadrotor states
   bool getQuadAct(Ref<Vector<>> act) const;
   bool getQuadState(Ref<Vector<>> state) const;

--- a/flightlib/src/envs/vision_env/vision_env.cpp
+++ b/flightlib/src/envs/vision_env/vision_env.cpp
@@ -487,7 +487,7 @@ bool VisionEnv::isTerminalState(Scalar &reward) {
   }
 
   if (quad_state_.x(QS::POSX) >= 60) {
-    reward = 10.0;
+    reward = 50.0;
     return true;
   }
   return false;

--- a/flightlib/src/envs/vision_env/vision_env.cpp
+++ b/flightlib/src/envs/vision_env/vision_env.cpp
@@ -429,7 +429,7 @@ bool VisionEnv::computeReward(Ref<Vector<>> reward) {
         ? relative_pos_norm_[sort_idx]
         : max_detection_range_;
 
-    const Scalar dist_margin = 0.5;
+    const Scalar dist_margin = 0.1;
     if (relative_pos_norm_[sort_idx] <=
         obstacle_radius_[sort_idx] + dist_margin) {
       // compute distance penalty
@@ -462,17 +462,13 @@ bool VisionEnv::computeReward(Ref<Vector<>> reward) {
 
 bool VisionEnv::isTerminalState(Scalar &reward) {
   if (is_collision_) {
-    if (quad_state_.v.norm() <= 2.0) {
-      reward = -10.0;
-    } else {
-      reward = fabs(quad_state_.v.norm()) * -10.0;
-    }
+    reward = -10.0;
     return true;
   }
 
   // simulation time out
   if (cmd_.t >= max_t_ - sim_dt_) {
-    reward = -1.0;
+    reward = -10.0;
     return true;
   }
 
@@ -486,12 +482,12 @@ bool VisionEnv::isTerminalState(Scalar &reward) {
   bool z_valid = quad_state_.x(QS::POSZ) >= world_box_[4] + safty_threshold &&
                  quad_state_.x(QS::POSZ) <= world_box_[5] - safty_threshold;
   if (!x_valid || !y_valid || !z_valid) {
-    reward = -1.0;
+    reward = -10.0;
     return true;
   }
 
   if (quad_state_.x(QS::POSX) >= 60) {
-    reward = 1.0;
+    reward = 10.0;
     return true;
   }
   return false;

--- a/flightlib/src/envs/vision_env/vision_env.cpp
+++ b/flightlib/src/envs/vision_env/vision_env.cpp
@@ -462,13 +462,17 @@ bool VisionEnv::computeReward(Ref<Vector<>> reward) {
 
 bool VisionEnv::isTerminalState(Scalar &reward) {
   if (is_collision_) {
-    reward = fabs(quad_state_.x(QS::VELX)) * -10.0;
+    if (quad_state_.v.norm() <= 1.0) {
+      reward = -1.0;
+    } else {
+      reward = fabs(quad_state_.v.norm()) * -1.0;
+    }
     return true;
   }
 
   // simulation time out
   if (cmd_.t >= max_t_ - sim_dt_) {
-    reward = -10.0;
+    reward = -1.0;
     return true;
   }
 
@@ -482,12 +486,12 @@ bool VisionEnv::isTerminalState(Scalar &reward) {
   bool z_valid = quad_state_.x(QS::POSZ) >= world_box_[4] + safty_threshold &&
                  quad_state_.x(QS::POSZ) <= world_box_[5] - safty_threshold;
   if (!x_valid || !y_valid || !z_valid) {
-    reward = -10.0;
+    reward = -1.0;
     return true;
   }
 
   if (quad_state_.x(QS::POSX) >= 60) {
-    reward = 30.0;
+    reward = 1.0;
     return true;
   }
   return false;

--- a/flightlib/src/envs/vision_env/vision_env.cpp
+++ b/flightlib/src/envs/vision_env/vision_env.cpp
@@ -462,10 +462,10 @@ bool VisionEnv::computeReward(Ref<Vector<>> reward) {
 
 bool VisionEnv::isTerminalState(Scalar &reward) {
   if (is_collision_) {
-    if (quad_state_.v.norm() <= 1.0) {
-      reward = -1.0;
+    if (quad_state_.v.norm() <= 2.0) {
+      reward = -10.0;
     } else {
-      reward = fabs(quad_state_.v.norm()) * -1.0;
+      reward = fabs(quad_state_.v.norm()) * -10.0;
     }
     return true;
   }

--- a/flightlib/src/envs/vision_env/vision_vec_env.cpp
+++ b/flightlib/src/envs/vision_env/vision_vec_env.cpp
@@ -123,7 +123,7 @@ void VisionVecEnv<EnvBaseName>::perAgentStep(int agent_id,
 
   if (done[agent_id]) {
     this->envs_[agent_id]->reset(obs.row(agent_id), random_reset_);
-    reward(agent_id, reward.cols() - 1) += terminal_reward;
+    reward(agent_id, reward.cols() - 1) = terminal_reward;
   }
 }
 

--- a/flightlib/src/envs/vision_env/vision_vec_env.cpp
+++ b/flightlib/src/envs/vision_env/vision_vec_env.cpp
@@ -123,7 +123,7 @@ void VisionVecEnv<EnvBaseName>::perAgentStep(int agent_id,
 
   if (done[agent_id]) {
     this->envs_[agent_id]->reset(obs.row(agent_id), random_reset_);
-    reward(agent_id, reward.cols() - 1) = terminal_reward;
+    reward(agent_id, reward.cols() - 1) += terminal_reward;
   }
 }
 

--- a/flightpy/configs/vision/config.yaml
+++ b/flightpy/configs/vision/config.yaml
@@ -8,7 +8,7 @@ environment:
 rewards:
   move_coeff: 0.1
   vel_coeff: -0.01
-  collision_coeff: -0.1
+  collision_coeff: -0.5
   angular_vel_coeff: -0.0001
   survive_rew: 0.03
   names:

--- a/flightpy/configs/vision/config.yaml
+++ b/flightpy/configs/vision/config.yaml
@@ -2,7 +2,7 @@ environment:
   level: ["hard"] # three difficulty level [easy, medium, hard]
   env_folder: "environment_0" # configurations for dynamic and static obstacles
   world_box: [-20, 80, -10, 10, 0.0, 10] # Bounding box applied during training, exiting this box terminates the episode. [xmin, xmax, ymin, ymax, zmin, zmax]
-  goal_vel: [3.0, 0.0, 0.0] # goal velicty for tracking vx, vy, vz
+  goal_vel: [5.0, 0.0, 0.0] # goal velicty for tracking vx, vy, vz
   max_detection_range: 10.0 # max obstacle detection range [m], obstacles outside this range will not be detected. The number of obstacles detected is fixed to 10, if less than 10 obstacles are within detectable range, the observation is padded with 10.0
 
 rewards:

--- a/flightpy/configs/vision/config.yaml
+++ b/flightpy/configs/vision/config.yaml
@@ -1,12 +1,12 @@
 environment:
-  level: ["easy", "medium", "hard"] # three difficulty level [easy, medium, hard]
+  level: ["hard"] # three difficulty level [easy, medium, hard]
   env_folder: "environment_0" # configurations for dynamic and static obstacles
   world_box: [-20, 80, -10, 10, 0.0, 10] # Bounding box applied during training, exiting this box terminates the episode. [xmin, xmax, ymin, ymax, zmin, zmax]
-  goal_vel: [5.0, 0.0, 0.0] # goal velicty for tracking vx, vy, vz
+  goal_vel: [3.0, 0.0, 0.0] # goal velicty for tracking vx, vy, vz
   max_detection_range: 10.0 # max obstacle detection range [m], obstacles outside this range will not be detected. The number of obstacles detected is fixed to 10, if less than 10 obstacles are within detectable range, the observation is padded with 10.0
 
 rewards:
-  move_coeff: 0.1
+  move_coeff: 0.3
   vel_coeff: -0.01
   collision_coeff: -0.5
   angular_vel_coeff: -0.0001
@@ -41,7 +41,7 @@ simulation:
   seed: 1
   sim_dt: 0.02
   max_t: 60.0
-  num_envs: 300 # overall; should be divisible by the number of difficulty levels given (in the best case)
+  num_envs: 100 # overall; should be divisible by the number of difficulty levels given (in the best case)
   num_threads: 12
 
 quadrotor_dynamics:


### PR DESCRIPTION
Implements the so-called "polar voxels": Basically the `kNFreePaths=9` number of the longest accessible paths from the drone in the goal (x-)direction, taken from `kNCuts=8` amount of rays shot in both y- and z-directions (overall 64 rays). The 'voxels' have a dimensionality of 4: (x, y, z) vector of direction + length of the ray until the next obstacle (10.0 if no obstacle).
These are taken into observation together with `kNObstacles=15` nearest obstacles.